### PR TITLE
Make inplace_function's default ctor constexpr-friendly

### DIFF
--- a/include/sg14/inplace_function.h
+++ b/include/sg14/inplace_function.h
@@ -216,8 +216,9 @@ public:
     using capacity = std::integral_constant<size_t, Capacity>;
     using alignment = std::integral_constant<size_t, Alignment>;
 
-    inplace_function() noexcept :
-        vtable_ptr_(std::addressof(inplace_function_detail::empty_vtable<R, Args...>))
+    constexpr inplace_function() noexcept :
+        vtable_ptr_(std::addressof(inplace_function_detail::empty_vtable<R, Args...>)),
+        storage_()
     {}
 
     template<

--- a/test/inplace_function_test.cpp
+++ b/test/inplace_function_test.cpp
@@ -46,6 +46,22 @@ static double GlobalFunction(const std::string& s, int i)
     return gNextReturn;
 }
 
+TEST(inplace_function, ConstinitDefaultConstructible)
+{
+    // C++20 introduced `constinit`, which is compatible with
+    // non-trivially destructible types like inplace_function.
+    // C++20 also relaxed the requirement that `constexpr` variables
+    // must have trivial destructors, but we don't take advantage
+    // of that yet.
+    //
+#if __cplusplus >= 202002L
+    static constinit sg14::inplace_function<void()> f;
+    EXPECT_FALSE(bool(f));
+    static constinit sg14::inplace_function<int(int)> g;
+    EXPECT_FALSE(bool(g));
+#endif
+}
+
 TEST(inplace_function, FunctionPointer)
 {
     // Even compatible function pointers require an appropriate amount of "storage".


### PR DESCRIPTION
The converting ctor (from function pointer or lambda) can't be constexpr pre-C++20, AFAIK, because it relies on `::new`. In C++20 we could do it; we'd have to introduce a new dependency on `<memory>` (for `std::construct_at`), but that's probably acceptable.